### PR TITLE
Semi-column was missing in &quote HTML entity

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -829,7 +829,7 @@ class Toolbox {
                        ? null : (is_resource($value)
                        ? $value : $DB->escape(
                           str_replace(
-                             ['&#039;', '&#39;', '&#x27;', '&quot'],
+                             ['&#039;', '&#39;', '&#x27;', '&quot;'],
                              ["'", "'", "'", "'"],
                              $value
                           )


### PR DESCRIPTION
Semi-column was missing in &quote HTML entity, and such when double-quotes were present in the text, they were converted into '; instead of '

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
